### PR TITLE
install the templatetags as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
-setup(name = "snippets",
-    version = "150",
+setup(name='snippets',
+    version = "151",
     description = "simple text/html snippet libraries for django",
     author = "Calvin Spealman",
     author_email = "ironfroggy@gmail.com",
     url = "http://github.com/ironfroggy/django-snippets",
-    packages = ['snippets']
+    packages=find_packages()
 )


### PR DESCRIPTION
after normal installation via 
`pip install git+https://github.com/ironfroggy/django-snippets.git#egg=snippets`

the templatetag package is missing
